### PR TITLE
Basic node setup for front-end unit testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test && npm run test:unit",
+    "test:unit": "qunit 'tests/node-qunit/**/*.test.js' | tap-mocha-reporter spec"
   },
   "devDependencies": {
     "eslint-config-wikimedia": "0.11.0",
@@ -10,7 +11,13 @@
     "grunt-eslint": "21.0.0",
     "grunt-jsonlint": "1.1.0",
     "grunt-stylelint": "0.10.1",
+    "jsdom": "14.0.0",
+    "oojs": "2.2.2",
+    "oojs-ui": "0.30.4",
+    "qunit": "2.9.2",
+    "sinon": "7.2.7",
     "stylelint": "9.10.1",
-    "stylelint-config-wikimedia": "0.5.0"
+    "stylelint-config-wikimedia": "0.5.0",
+    "tap-mocha-reporter": "3.0.7"
   }
 }

--- a/resources/filepage/LicenseDialogWidget.js
+++ b/resources/filepage/LicenseDialogWidget.js
@@ -23,7 +23,7 @@
 	 */
 	sd.LicenseDialogWidget.prototype.getConfirmationIfNecessary = function () {
 		var deferred = $.Deferred(),
-			confirmed = this.getLicenceConfirmation(),
+			confirmed = this.getLicenseConfirmation(),
 			self = this;
 
 		// check if we've agreed to this before, either in present
@@ -79,7 +79,7 @@
 	 * been set.
 	 * @returns {Number} 0 or 1
 	 */
-	sd.LicenseDialogWidget.prototype.getLicenceConfirmation = function () {
+	sd.LicenseDialogWidget.prototype.getLicenseConfirmation = function () {
 		var storage = mw.storage,
 			key = this.prefKey,
 			user = mw.user;
@@ -109,5 +109,7 @@
 			user.options.set( key, 1 );
 		}
 	};
+
+	module.exports = sd.LicenseDialogWidget;
 
 }( mw.mediaInfo.structuredData ) );

--- a/tests/node-qunit/.eslintrc.json
+++ b/tests/node-qunit/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+	"extends": [
+		"wikimedia/qunit",
+		"../../.eslintrc.json"
+	],
+	"globals": {
+		"global": true,
+		"require": true
+	},
+	"rules": {
+		"no-new": "off",
+		"no-implicit-globals": "off"
+	}
+}

--- a/tests/node-qunit/helpers.js
+++ b/tests/node-qunit/helpers.js
@@ -1,0 +1,39 @@
+var sinon = require( 'sinon' );
+
+module.exports.createMediaWikiEnv = function () {
+	return {
+		mediaInfo: {
+			structuredData: {}
+		}
+	};
+};
+
+module.exports.createMediaWikiUser = function ( options ) {
+	options = options || {};
+
+	var user = {
+		options: {}
+	};
+
+	if ( options.loggedIn ) {
+		user.isAnon = sinon.stub().returns( false );
+		user.options.set = sinon.stub();
+	} else {
+		user.isAnon = sinon.stub().returns( true );
+	}
+
+	if ( options.licenseAccepted ) {
+		user.options.get = sinon.stub().returns( 1 );
+	} else {
+		user.options.get = sinon.stub().returns( 0 );
+	}
+
+	return user;
+};
+
+module.exports.createMockStorage = function () {
+	return {
+		get: sinon.stub(),
+		set: sinon.stub()
+	};
+};

--- a/tests/node-qunit/mediainfo/example.test.js
+++ b/tests/node-qunit/mediainfo/example.test.js
@@ -1,0 +1,77 @@
+var jsdom = require( 'jsdom' ),
+	sinon = require( 'sinon' ),
+	helpers = require( '../helpers.js' ),
+	LicenseDialogWidget,
+	sandbox,
+	dom;
+
+QUnit.module( 'LicenseDialogWidget', {
+	beforeEach: function () {
+		sandbox = sinon.createSandbox();
+		dom = new jsdom.JSDOM( '<!doctype html><html><body></body></html>' );
+		global.window = dom.window;
+		global.document = global.window.document;
+		global.jQuery = global.$ = window.jQuery = window.$ = require( 'jquery' );
+		global.OO = require( 'oojs' );
+		global.OO.ui = require( '../ooui.js' );
+		global.mw = helpers.createMediaWikiEnv();
+	},
+
+	afterEach: function () {
+		sandbox.reset();
+	}
+}, function () {
+	QUnit.test( 'constructor', function ( assert ) {
+		LicenseDialogWidget = require( '../../../resources/filepage/LicenseDialogWidget.js' );
+		new LicenseDialogWidget();
+		assert.ok( true );
+	} );
+
+	QUnit.module( 'User is not logged in and has not accepted license', {
+		beforeEach: function () {
+			global.mw.user = helpers.createMediaWikiUser();
+			global.mw.storage = helpers.createMockStorage();
+		}
+	}, function () {
+		QUnit.test( 'getLicenseConfirmation returns zero', function ( assert ) {
+			LicenseDialogWidget = require( '../../../resources/filepage/LicenseDialogWidget.js' );
+			var dialog = new LicenseDialogWidget();
+			assert.strictEqual( dialog.getLicenseConfirmation(), 0 );
+		} );
+
+		QUnit.test( 'storeLicenseConfirmation sets value of the appropriate key to 1', function ( assert ) {
+			LicenseDialogWidget = require( '../../../resources/filepage/LicenseDialogWidget.js' );
+			var dialog = new LicenseDialogWidget();
+			dialog.storeLicenseConfirmation();
+			assert.strictEqual( global.mw.storage.set.calledWith( dialog.prefKey, 1 ), true );
+		} );
+	} );
+
+	QUnit.module( 'User is not logged in and has accepted license', {
+		beforeEach: function () {
+			global.mw.user = helpers.createMediaWikiUser( {
+				loggedIn: true,
+				licenseAccepted: false
+			} );
+			global.mw.storage = helpers.createMockStorage();
+			global.mw.Api = function () {};
+			global.mw.Api.prototype = {
+				saveOption: sinon.stub()
+			};
+		}
+	}, function () {
+		QUnit.test( 'getLicenseConfirmation returns zero', function ( assert ) {
+			LicenseDialogWidget = require( '../../../resources/filepage/LicenseDialogWidget.js' );
+			var dialog = new LicenseDialogWidget();
+			assert.strictEqual( dialog.getLicenseConfirmation(), 0 );
+		} );
+
+		QUnit.test( 'storeLicenseConfirmation saves to user preferences', function ( assert ) {
+			LicenseDialogWidget = require( '../../../resources/filepage/LicenseDialogWidget.js' );
+			var dialog = new LicenseDialogWidget();
+
+			dialog.storeLicenseConfirmation();
+			assert.strictEqual( mw.Api.prototype.saveOption.calledWith( dialog.prefKey, 1 ), true );
+		} );
+	} );
+} );

--- a/tests/node-qunit/ooui.js
+++ b/tests/node-qunit/ooui.js
@@ -1,0 +1,32 @@
+/* eslint no-eval: "off" */
+/* eslint no-unused-vars: "off" */
+
+/**
+ * OOUI Shim for node QUnit tests.
+ * UI elements in this extension depend heavily on the OOJS-UI library. The
+ * parent OOJS lib includes a `module.exports` statement which allows it to be
+ * consumed as a module via `require()`. OOUI does not expose a module in this
+ * way currently; the library is intended to be made globally avalable through
+ * the inclusion of a <script> tag.
+ *
+ * This file acts as a wrapper for OOUI in a node environment. The relevant
+ * scripts in the package /dist folder are loaded into an isolated scope using
+ * `eval()` and then are exported as a module.
+ */
+( function () {
+	var fs = require( 'fs' ),
+		OO = require( 'oojs' );
+
+	function evalFile( path ) {
+		function read( path ) {
+			return fs.readFileSync( 'node_modules/oojs-ui/' + path, 'utf8' );
+		}
+
+		eval( read( path ) );
+	}
+
+	evalFile( 'dist/oojs-ui.js' );
+	evalFile( 'dist/oojs-ui-wikimediaui.js' );
+
+	module.exports = OO.ui;
+}() );


### PR DESCRIPTION
This patch represents an attempt at getting a front-end testing strategy in
place that relies on node CLI tools instead of Special:JavascriptTest. The
implementation here is inspired by Jdlrobson's proof-of-concept patch in core
(https://gerrit.wikimedia.org/r/c/mediawiki/core/+/487168/) and the test suites
that the Readers Web team has set up in some of their extensions (Popups and
MobileFrontend, for example).

Using a headless node environment for JS unit tests has some advantages over the
traditional browser-based approach:

* Easier to run just the tests we are interested in during the development of
  this extension
* Still compatible with Jenkins & CI pipeline
* Easier to test different use-cases (logged in users vs non-logged-in users,
  for example) in the context of a single method by stubbing/mocking with Sinon
* The ability to `require` a single module makes tests easier to write

This approach does not require any changes in how front-end code is delivered to
users (it does not require the use of Webpack). However, it does require that a
`module.exports` statement be added to any file that will be tested this way, so
that the code can be consumed in a node environment. These exposed modules could
be used in front-end code down the road if desired (thanks to ResourceLoader's
new PackageModules feature) but this is optional.

Description of changes:

* Adds a `test:unit` script to package.json, as well as a series of new dev
  dependencies that are used in the node test suite. This script is included in
  the top-level "test" script, so these tests will run on Jenkins.
* Adds a JS unit test suite in the tests/node-qunit directory. Currently this
  includes:
  - an .eslintrc.json file for the test files (probably needs to be further
    refined)
  - a shim to enable the OOUI library in a headless environment; see the
    comments in that file for more info; ideally this is only something that
    will be needed temporarily
  - a helpers file to assist in mocking various parts of the MW environment
  - adds an example test file that tests the LicenseDialogWidget element
* Adds a `module.exports` line to the LicenseDialogWidget file so that it can be
  consumed as a JS module

To run these tests locally, install the dependencies and then run:

npm run test

Bug: T216229
Change-Id: I540081115818cfb9b9a3a6fd4d297fed74acc4ad