### PR TITLE
Fix Typo

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -95,7 +95,7 @@
 	"wikibasemediainfo-time-precision-year1m": "million years",
 	"wikibasemediainfo-time-precision-year100k": "100,000 years",
 	"wikibasemediainfo-time-precision-year10k": "10,000 years",
-	"wikibasemediainfo-time-precision-year1k": "millenium",
+	"wikibasemediainfo-time-precision-year1k": "millennium",
 	"wikibasemediainfo-time-precision-year100": "century",
 	"wikibasemediainfo-time-precision-year10": "decade",
 	"wikibasemediainfo-time-precision-year": "year",


### PR DESCRIPTION
## Changes

https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/WikibaseMediaInfo/+/23e6e07652a171237f975e2763f5c7a626ac7333/i18n/en.json in wikibasemediainfo-time-precision-year1k, "millenium" should be "millennium".

## Phabricator Ticket
[//]: # https://phabricator.wikimedia.org/T253060